### PR TITLE
Update pre-commit hooks and black

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,7 +3,7 @@
 exclude: testfiles/|\.(csv|ipynb)$
 repos:
 - repo: https://github.com/pre-commit/pre-commit-hooks
-  rev: v4.4.0
+  rev: v4.5.0
   hooks:
     - id: check-merge-conflict
     - id: check-toml
@@ -16,6 +16,6 @@ repos:
     - id: isort
       name: isort
 - repo: https://github.com/psf/black
-  rev: 22.3.0
+  rev: 23.11.0
   hooks:
     - id: black


### PR DESCRIPTION
to trigger the CLA assistant again