### PR TITLE
fix dw5 parsing temperature_pv

### DIFF
--- a/detl/parsing/dw5.py
+++ b/detl/parsing/dw5.py
@@ -39,7 +39,7 @@ BLOCKPARSERS = {
 columnmapping = {
     "volume_pv": "\\.V\\d+\\.VPV",
     "temperature_sp": "\\.T\\d+\\.SP",
-    "temperature_pv": "\\.\\.T\\d+\\.PV",
+    "temperature_pv": r"Unit.\d.T\d.+PV",
     "temperature_out": "\\.T\\d+\\.Out",
     "stirrer_speed_sp": "\\.N\\d+\\.SP",
     "stirrer_speed_pv": "\\.N\\d+\\.PV",

--- a/tests/test_detl.py
+++ b/tests/test_detl.py
@@ -200,6 +200,7 @@ class TestDW5Parsing(unittest.TestCase):
 
         assert "pump_a_rate_sp" in ddata[1].dataframe.columns
         assert "pump_b_rate_sp" in ddata[1].dataframe.columns
+        assert "temperature_pv" in ddata[1].dataframe.columns
 
         self.assertAlmostEqual(ddata[1].dataframe.loc[11359, "aeration_x_co2_pv"], 0.034, places=3)
         self.assertAlmostEqual(ddata[2].dataframe.loc[4128, "stirrer_speed_pv"], 1059.382, places=3)


### PR DESCRIPTION
I adjusted the regex, to work with **Unit 1.T1.PV**

#33 

